### PR TITLE
fix(container): security settings of favonia/cloudflare-ddns

### DIFF
--- a/config-parts/2-container.sh
+++ b/config-parts/2-container.sh
@@ -162,14 +162,14 @@ set container name cloudflare-ddns environment CF_API_TOKEN value "${SECRET_CLOU
 set container name cloudflare-ddns environment DOMAINS value "${SECRET_CF_CNAME1}"
 set container name cloudflare-ddns environment IP4_PROVIDER value 'local'
 set container name cloudflare-ddns environment IP6_PROVIDER value 'none'
-set container name cloudflare-ddns environment PGID value '1000'
-set container name cloudflare-ddns environment PUID value '1000'
 set container name cloudflare-ddns environment TZ value "${SECRET_TIMEZONE}"
 set container name cloudflare-ddns environment UPDATE_CRON value '@every 2m'
+set container name cloudflare-ddns gid '1000'
 set container name cloudflare-ddns image 'docker.io/favonia/cloudflare-ddns:1.11.0'
 set container name cloudflare-ddns memory '0'
 set container name cloudflare-ddns restart 'on-failure'
 set container name cloudflare-ddns shared-memory '0'
+set container name cloudflare-ddns uid '1000'
 
 # Node Exporter
 set container name node-exporter allow-host-networks


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16) (released on 16 July), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer, cleaner, and more reliable; but it requires an update to the configuration. In particular, the environment variables `PUID=uid` and `PGID=gid` should be replaced by `user: "uid:gid"` or `--user uid:gid`. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in the updater.

_PS:_ I know you are using an older version of the updater, but the template works even for older ones. (An upgrade is recommended, though.)
_PPS:_ I do not have a VyOS to test the script. Please let me know whether it works or not. BTW, it’s sad that VyOS does not seem to provide many other useful protections such as “dropping all Linux capabilities” or “making the filesystem read-only”.